### PR TITLE
interfaces.rkt: do not assume that netstat is in the path

### DIFF
--- a/interfaces.rkt
+++ b/interfaces.rkt
@@ -19,7 +19,13 @@
     (findf
      (lambda (r) (and (pair? r) (member (car r) '("default" "0.0.0.0"))))
      (map string-split
-	  (string-split (with-output-to-string (lambda () (system "netstat -rn"))) "\n"))))
+	  (string-split
+           (with-output-to-string
+             (lambda ()
+               (if (file-exists? "/usr/sbin/netstat")
+                   (system "/usr/sbin/netstat -rn") ; if it's where we expect, call it directly
+                   (system "netstat -rn"))))       ; if not, hope that it's in the user's path
+           "\n"))))
   (when (not r)
     (error 'gateway-ip-address "Cannot determine gateway IP address"))
   (cadr r))


### PR DESCRIPTION
gateway-ip-address was failing because `(system "netstat -rn")` was failing because netstat wasn't in my path.  I changed it to check for an expected path of /usr/sbin/netstat and, if found, use that and if not then default to the original code and hope it's in the path.