### PR TITLE
Improve documentation

### DIFF
--- a/scribblings/nat-traversal.scrbl
+++ b/scribblings/nat-traversal.scrbl
@@ -46,7 +46,7 @@ NAT port mappings by simply changing calls to @racket[udp-bind!] and
 Each socket managed by the library is associated with a
 @racket[mapping-change-listener], a background thread that tracks
 changes to the NAT configuration, keeping a set of "port assignments"
-up-to-date. A user-supplied callback (@tt{on-mapping-change}) is
+up-to-date. A user-supplied callback (@racket[_on-mapping-change]) is
 called every time the port assignment set changes.
 
 Each port assignment in a set is an address at which the corresponding

--- a/scribblings/nat-traversal.scrbl
+++ b/scribblings/nat-traversal.scrbl
@@ -90,7 +90,8 @@ Opens and starts managing a TCP or UDP port mapping at the local NAT
 for the given port. This routine is the workhorse that both
 @racket[udp-bind!/public] and @racket[tcp-listen/public] delegate to.}
 
-@defstruct*[mapping-change-listener ([thread thread?]) #:prefab]{
+@deftogether[(@defproc[(mapping-change-listener? [v any/c]) boolean?]
+              @defproc[(mapping-change-listener-thread [m mapping-change-listener?]) thread?])]{
 Handle for a mapping change listener. Useful with
 @racket[mapping-change-listener-stop!] and so forth.}
 


### PR DESCRIPTION
I noticed a build warning during `raco setup` and made another small tweak on the way to fixing it.

Details:
- 9046e26 (docs: mark a racket meta-variable so it stands out, 2024-11-23)
- 818da6b (docs: fix build warning (collected multiple info for make-mapping-change-listener), 2024-11-23)